### PR TITLE
Add support for the dynamic CSS styling of the item tallycounters

### DIFF
--- a/src/interface.js
+++ b/src/interface.js
@@ -144,13 +144,18 @@
             });
     }
 
-    // undocumented UI helper
+    // itemCount(itemID, prefix, postfix) -> returns stack tallycount
     function itemCount (self, id, pre, post) {
+        let tally = $(document.createElement('span'));
+        let cnt = self.count(id);
+
         pre = pre || Inventory.strings.stackPre;
         post = post || Inventory.strings.stackPost;
-        return $(document.createElement('span'))
-            .addClass('item-count')
-            .append( "" + pre + (self.count(id) || 0) + post );
+        
+        if (cnt == 1) tally.addClass('item-count single');
+        else tally.addClass('item-count multi');
+        
+        return tally.append( "" + pre + (cnt || 0) + post );
     }
 
     // undocumented UI helper


### PR DESCRIPTION
Stacks composed of a single item will now have the `.single` CSS class; when multiple item of the same type are present, the `.multi` CSS class will be used instead.

---

<details>
<summary>[Example] Hide unnecessary tallycounters</summary>

```
/* hide the tallycount if the stack contains only a single element */
.item-count.single {
  visibility: hidden;
}
```

</details>

<details>
<summary>[Example] Add warning for the item scarcity</summary>

```
/* append a warning message to the tallycount of the stacks composed of a single item */
.item-count.single::after {
  content: '(warning - low)';
  color: red;
}
```

</details>

<details>
<summary>[Example] Highlight multiple items</summary>

```
/* highlight the tallycount if the stack contains multiple elements */
.item-count.multi {
  font-weight: bold;
}
```

</details>


